### PR TITLE
fix: try preload all workspaces

### DIFF
--- a/src/UI5TSParser.ts
+++ b/src/UI5TSParser.ts
@@ -55,14 +55,21 @@ export class UI5TSParser extends AbstractUI5Parser<CustomTSClass | CustomTSObjec
 	}
 
 	protected async _preloadAllNecessaryData(wsFolders: WorkspaceFolder[]) {
-		const initializedProjects = wsFolders.map(wsFolder => {
-			const { project, paths, sourceFiles } = this._initializeTS(wsFolder.fsPath);
-			const projectPaths = paths.map(initializedPath =>
-				path.resolve(wsFolder.fsPath, initializedPath.replace(/\*/g, ""))
-			);
+		const initializedProjects = [];
 
-			return { projectPaths, sourceFiles, project };
-		});
+		for (const wsFolder of wsFolders) {
+			try {
+				const { project, paths, sourceFiles } = this._initializeTS(wsFolder.fsPath);
+				const projectPaths = paths.map(initializedPath =>
+					path.resolve(wsFolder.fsPath, initializedPath.replace(/\*/g, ""))
+				);
+
+				initializedProjects.push({ projectPaths, sourceFiles, project });
+			} catch (error) {
+				continue;
+			}
+		}
+
 		const paths = initializedProjects.flatMap(project => project.projectPaths);
 		const notDuplicatedPaths = paths.filter(initializedPath => {
 			return !wsFolders.some(wsFolder => initializedPath.startsWith(wsFolder.fsPath));


### PR DESCRIPTION
When trying to preload workspace folders, the process no longer stops when the first workspace folder cannot be processed. Instead, only the valid ones are kept.

fixes #59 