### PR TITLE
fix: FileReader getManifestForClass returns wrong manifest in multiproject workspace #68

### DIFF
--- a/src/classes/utils/FileReader.ts
+++ b/src/classes/utils/FileReader.ts
@@ -185,12 +185,9 @@ export class FileReader implements IFileReader {
 
 	public getManifestForClass(className = "") {
 		let  componetNameList = this._manifests.map(element => element.componentName );
-		componetNameList.sort(function(a, b){
-            return b.length - a.length;
-        });
+		componetNameList.sort(function(a, b) { return b.length - a.length; });
 		let componentName = componetNameList.find(componentName => className.startsWith(componentName + "."));
 		const returnManifest = this._manifests.find(UIManifest => UIManifest.componentName === componentName );
-		//const returnManifest = this._manifests.find(UIManifest => className.startsWith(UIManifest.componentName + "."));
 
 		return returnManifest;
 	}

--- a/src/classes/utils/FileReader.ts
+++ b/src/classes/utils/FileReader.ts
@@ -184,7 +184,13 @@ export class FileReader implements IFileReader {
 	}
 
 	public getManifestForClass(className = "") {
-		const returnManifest = this._manifests.find(UIManifest => className.startsWith(UIManifest.componentName + "."));
+		let  componetNameList = this._manifests.map(element => element.componentName );
+		componetNameList.sort(function(a, b){
+            return b.length - a.length;
+        });
+		let componentName = componetNameList.find(componentName => className.startsWith(componentName + "."));
+		const returnManifest = this._manifests.find(UIManifest => UIManifest.componentName === componentName );
+		//const returnManifest = this._manifests.find(UIManifest => className.startsWith(UIManifest.componentName + "."));
 
 		return returnManifest;
 	}


### PR DESCRIPTION
Finding manifest for the class takes in account component name length. It will return manifest with the longest match.
Solution creates new array, sort it by component name length and then finds first manifest using startsWith. Perhaps better would be to persist the sorted array or to sort original _manifests.